### PR TITLE
Fix for alternative temperature UOMs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jlucaspains/sharp-recipe-parser",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Recipe parsing tools",
   "main": "lib/index.js",
   "scripts": {

--- a/src/instructionParser.ts
+++ b/src/instructionParser.ts
@@ -117,7 +117,7 @@ function getTemperatureConversions(
   return defaultConversions
     .filter((item) => item !== unit.symbol)
     .map((possibility: string) => {
-      const possibilityUOM = units.ingredientUnits.get(possibility);
+      const possibilityUOM = units.temperatureUnits.get(possibility);
       const quantity = convert(temperature, unit.symbol, possibility, units);
 
       const rounded = round(quantity, 0, 4);

--- a/test/index_en.spec.ts
+++ b/test/index_en.spec.ts
@@ -327,7 +327,14 @@ describe("Parse instruction en-US", () => {
 
 describe("Parse instruction with options en-US", () => {
   const table = [
-    ["Preheat the oven at 450 fahrenheit", 450, "fahrenheit", 232.2222, "c", "celsius"],
+    [
+      "Preheat the oven at 450 fahrenheit",
+      450,
+      "fahrenheit",
+      232.2222,
+      "c",
+      "celsius",
+    ],
     ["Preheat the oven at 450F", 450, "fahrenheit", 232.2222, "c", "celsius"],
     ["Preheat the oven at 450 celsius", 450, "celsius", 842, "f", "fahrenheit"],
     ["Preheat the oven at 450C", 450, "celsius", 842, "f", "fahrenheit"],
@@ -337,7 +344,7 @@ describe("Parse instruction with options en-US", () => {
       "fahrenheit",
       260,
       "c",
-      "celsius"
+      "celsius",
     ],
     ["Bake", 0, "", 0, "", ""],
   ];

--- a/test/index_en.spec.ts
+++ b/test/index_en.spec.ts
@@ -327,20 +327,23 @@ describe("Parse instruction en-US", () => {
 
 describe("Parse instruction with options en-US", () => {
   const table = [
-    ["Preheat the oven at 450 fahrenheit", 450, "fahrenheit", 232.2222, "c"],
-    ["Preheat the oven at 450 celsius", 450, "celsius", 842, "f"],
+    ["Preheat the oven at 450 fahrenheit", 450, "fahrenheit", 232.2222, "c", "celsius"],
+    ["Preheat the oven at 450F", 450, "fahrenheit", 232.2222, "c", "celsius"],
+    ["Preheat the oven at 450 celsius", 450, "celsius", 842, "f", "fahrenheit"],
+    ["Preheat the oven at 450C", 450, "celsius", 842, "f", "fahrenheit"],
     [
       "Preheat the oven at 450 fahrenheit then adjust to 500F",
       500, // keep the last temperature
       "fahrenheit",
       260,
       "c",
+      "celsius"
     ],
-    ["Bake", 0, "", 0, ""],
+    ["Bake", 0, "", 0, "", ""],
   ];
   it.each(table)(
     "parse %s",
-    (text, temperature, temperatureUnit, altTemp, altTempUOM) => {
+    (text, temperature, temperatureUnit, altTemp, altTempUOM, altTempName) => {
       const result = parseInstruction(text as string, "en-US", {
         includeAlternativeTemperatureUnit: true,
       });
@@ -355,6 +358,7 @@ describe("Parse instruction with options en-US", () => {
             expect.objectContaining({
               quantity: altTemp,
               unit: altTempUOM,
+              unitText: altTempName,
               minQuantity: altTemp,
               maxQuantity: altTemp,
             }),


### PR DESCRIPTION
parseInstruction with alternative UOM is returning cup instead of celsius. This is happening because the wrong UOM is picked up during conversion.