### PR TITLE
Added fallback language option

### DIFF
--- a/src/ingredientParser.js
+++ b/src/ingredientParser.js
@@ -55,7 +55,7 @@ const unicodeFractions = {
 const defaultParseIngredientOptions = {
   includeAlternativeUnits: false,
   includeExtra: true,
-  fallbackLanguage: ""
+  fallbackLanguage: "",
 };
 
 /**
@@ -78,7 +78,9 @@ export function parseIngredient(
   }
 
   if (!units) {
-    throw new Error(`Language ${language} is not supported and no fallback language is provided`);
+    throw new Error(
+      `Language ${language} is not supported and no fallback language is provided`,
+    );
   }
 
   const tokens = tokenize(text, false);

--- a/src/ingredientParser.js
+++ b/src/ingredientParser.js
@@ -21,6 +21,7 @@ import { convert, getUnits, round } from "./units.js";
  * @typedef {{
  *  includeExtra: boolean;
  *  includeAlternativeUnits: boolean;
+ *  fallbackLanguage: string;
  * }} ParseIngredientOptions
  */
 
@@ -54,6 +55,7 @@ const unicodeFractions = {
 const defaultParseIngredientOptions = {
   includeAlternativeUnits: false,
   includeExtra: true,
+  fallbackLanguage: ""
 };
 
 /**
@@ -69,10 +71,14 @@ export function parseIngredient(
   language,
   options = defaultParseIngredientOptions,
 ) {
-  const units = getUnits(language);
+  let units = getUnits(language);
+
+  if (!units && options.fallbackLanguage) {
+    units = getUnits(options.fallbackLanguage);
+  }
 
   if (!units) {
-    throw new Error(`Language ${language} is not supported`);
+    throw new Error(`Language ${language} is not supported and no fallback language is provided`);
   }
 
   const tokens = tokenize(text, false);

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -53,9 +53,11 @@ test("Parse ingredient with unknown language with fallback en", () => {
 });
 
 test("Parse ingredient with unknown language with invalid fallback", () => {
-  expect(() => parseIngredient("some ingredient", "en-CA", {
-    fallbackLanguage: "en-CA",
-  })).toThrow(
+  expect(() =>
+    parseIngredient("some ingredient", "en-CA", {
+      fallbackLanguage: "en-CA",
+    }),
+  ).toThrow(
     "Language en-CA is not supported and no fallback language is provided",
   );
 });

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -19,32 +19,36 @@ test("Parse ingredient with unknown language no fallback", () => {
 });
 
 test("Parse ingredient with unknown language with fallback en-CA", () => {
-  const result = parseIngredient("1 cup flour", "en-CA", { fallbackLanguage: "en-US" });
+  const result = parseIngredient("1 cup flour", "en-CA", {
+    fallbackLanguage: "en-US",
+  });
   expect(result).toEqual({
-    "alternativeQuantities": [],
-    "extra": "",
-    "ingredient": "flour",
-    "maxQuantity": 1,
-    "minQuantity": 1,
-    "quantity": 1,
-    "quantityText": "1",
-    "unit": "cup",
-    "unitText": "cup",
+    alternativeQuantities: [],
+    extra: "",
+    ingredient: "flour",
+    maxQuantity: 1,
+    minQuantity: 1,
+    quantity: 1,
+    quantityText: "1",
+    unit: "cup",
+    unitText: "cup",
   });
 });
 
 test("Parse ingredient with unknown language with fallback en", () => {
-  const result = parseIngredient("1 cup flour", "en", { fallbackLanguage: "en-US" });
+  const result = parseIngredient("1 cup flour", "en", {
+    fallbackLanguage: "en-US",
+  });
   expect(result).toEqual({
-    "alternativeQuantities": [],
-    "extra": "",
-    "ingredient": "flour",
-    "maxQuantity": 1,
-    "minQuantity": 1,
-    "quantity": 1,
-    "quantityText": "1",
-    "unit": "cup",
-    "unitText": "cup",
+    alternativeQuantities: [],
+    extra: "",
+    ingredient: "flour",
+    maxQuantity: 1,
+    minQuantity: 1,
+    quantity: 1,
+    quantityText: "1",
+    unit: "cup",
+    unitText: "cup",
   });
 });
 

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -18,7 +18,7 @@ test("Parse ingredient with unknown language no fallback", () => {
   );
 });
 
-test("Parse ingredient with unknown language with fallback en-CA", () => {
+test("Parse ingredient with unknown language with fallback en-US", () => {
   const result = parseIngredient("1 cup flour", "en-CA", {
     fallbackLanguage: "en-US",
   });
@@ -36,8 +36,8 @@ test("Parse ingredient with unknown language with fallback en-CA", () => {
 });
 
 test("Parse ingredient with unknown language with fallback en", () => {
-  const result = parseIngredient("1 cup flour", "en", {
-    fallbackLanguage: "en-US",
+  const result = parseIngredient("1 cup flour", "en-CA", {
+    fallbackLanguage: "en",
   });
   expect(result).toEqual({
     alternativeQuantities: [],
@@ -50,6 +50,14 @@ test("Parse ingredient with unknown language with fallback en", () => {
     unit: "cup",
     unitText: "cup",
   });
+});
+
+test("Parse ingredient with unknown language with invalid fallback", () => {
+  expect(() => parseIngredient("some ingredient", "en-CA", {
+    fallbackLanguage: "en-CA",
+  })).toThrow(
+    "Language en-CA is not supported and no fallback language is provided",
+  );
 });
 
 test("Parse ingredient with null language", () => {

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -12,6 +12,27 @@ test("Parse ingredient with null language", () => {
   );
 });
 
+test("Parse ingredient with unknown language no fallback", () => {
+  expect(() => parseIngredient("some ingredient", "en-CA")).toThrow(
+    "Language en-CA is not supported and no fallback language is provided",
+  );
+});
+
+test("Parse ingredient with unknown language with fallback", () => {
+  const result = parseIngredient("1 cup flour", "en-CA", { fallbackLanguage: "en-US" });
+  expect(result).toEqual({
+    "alternativeQuantities": [],
+    "extra": "",
+    "ingredient": "flour",
+    "maxQuantity": 1,
+    "minQuantity": 1,
+    "quantity": 1,
+    "quantityText": "1",
+    "unit": "cup",
+    "unitText": "cup",
+  });
+});
+
 test("Parse ingredient with null language", () => {
   expect(() => parseIngredient("some ingredient", undefined)).toThrow(
     "Language undefined is not supported",

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -18,8 +18,23 @@ test("Parse ingredient with unknown language no fallback", () => {
   );
 });
 
-test("Parse ingredient with unknown language with fallback", () => {
+test("Parse ingredient with unknown language with fallback en-CA", () => {
   const result = parseIngredient("1 cup flour", "en-CA", { fallbackLanguage: "en-US" });
+  expect(result).toEqual({
+    "alternativeQuantities": [],
+    "extra": "",
+    "ingredient": "flour",
+    "maxQuantity": 1,
+    "minQuantity": 1,
+    "quantity": 1,
+    "quantityText": "1",
+    "unit": "cup",
+    "unitText": "cup",
+  });
+});
+
+test("Parse ingredient with unknown language with fallback en", () => {
+  const result = parseIngredient("1 cup flour", "en", { fallbackLanguage: "en-US" });
   expect(result).toEqual({
     "alternativeQuantities": [],
     "extra": "",


### PR DESCRIPTION
This pull request enhances the ingredient parser by introducing support for a fallback language when the primary language is unsupported. It also updates the test suite to cover scenarios involving fallback language usage.

### Enhancements to ingredient parsing:

* Added a `fallbackLanguage` property to the `ParseIngredientOptions` type definition, allowing the parser to attempt parsing with a secondary language if the primary language is unsupported. (`src/ingredientParser.js`, [src/ingredientParser.jsR24](diffhunk://#diff-cddac104da46bf73862b52b75bea3d3fde7a5195d3bb046604a2feb9097cfdb0R24))
* Updated the `defaultParseIngredientOptions` object to include an empty string as the default value for `fallbackLanguage`. (`src/ingredientParser.js`, [src/ingredientParser.jsR58](diffhunk://#diff-cddac104da46bf73862b52b75bea3d3fde7a5195d3bb046604a2feb9097cfdb0R58))
* Modified the `parseIngredient` function to use the `fallbackLanguage` option when the primary language is unsupported, and updated the error message to reflect this behavior. (`src/ingredientParser.js`, [src/ingredientParser.jsL72-R81](diffhunk://#diff-cddac104da46bf73862b52b75bea3d3fde7a5195d3bb046604a2feb9097cfdb0L72-R81))

### Test suite updates:

* Added new tests to validate the behavior of the `parseIngredient` function when using fallback language options, including scenarios with and without fallback language specified. (`test/index_invalid.spec.js`, [test/index_invalid.spec.jsR15-R50](diffhunk://#diff-5ca8b91654dd88a6128c8a9b18345d761cd90364f88190fef68874759d332f68R15-R50))