### PR TITLE
Fixed release pipeline

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
           always-auth: true
           registry-url: 'https://registry.npmjs.org'
 


### PR DESCRIPTION
This pull request updates the Node.js version used in the release workflow configuration to ensure compatibility with the latest features and security updates.

* [`.github/workflows/release-package.yml`](diffhunk://#diff-3099c6260c6951cb01f86e1ae6d3445e822dfd243571b51a1737ec2cee3a7e56L19-R19): Changed the `node-version` from `18` to `20` in the `setup-node` action to use the latest stable version of Node.js.