### PR TITLE
Added fallback to instruction parser

### DIFF
--- a/src/instructionParser.js
+++ b/src/instructionParser.js
@@ -25,6 +25,7 @@ import { getUnits, convert, round } from "./units.js";
 /**
  * @typedef {{
  *  includeAlternativeTemperatureUnit: boolean;
+ *  fallbackLanguage: string;
  * }} ParseInstructionOptions
  */
 
@@ -33,6 +34,7 @@ import { getUnits, convert, round } from "./units.js";
  */
 const defaultParseInstructionOptions = {
   includeAlternativeTemperatureUnit: false,
+  fallbackLanguage: "",
 };
 
 /**
@@ -50,10 +52,16 @@ export function parseInstruction(
   language,
   options = defaultParseInstructionOptions,
 ) {
-  const units = getUnits(language);
+  let units = getUnits(language);
+
+  if (!units && options.fallbackLanguage) {
+    units = getUnits(options.fallbackLanguage);
+  }
 
   if (!units) {
-    throw new Error(`Language ${language} is not supported`);
+    throw new Error(
+      `Language ${language} is not supported and fallback language ${options.fallbackLanguage} is not available.`,
+    );
   }
 
   const tokens = tokenize(text);

--- a/test/index_invalid.spec.js
+++ b/test/index_invalid.spec.js
@@ -96,6 +96,42 @@ test("Parse instruction with null language", () => {
   );
 });
 
+test("Parse instruction with unknown language no fallback", () => {
+  expect(() => parseInstruction("some instruction", "en-CA")).toThrow(
+    "Language en-CA is not supported and fallback language  is not available.",
+  );
+});
+
+test("Parse instruction with unknown language with fallback en-US", () => {
+  const result = parseInstruction("some instruction", "en-CA", {
+    fallbackLanguage: "en-US",
+  });
+  expect(result).toEqual({
+    totalTimeInSeconds: 0,
+    timeItems: [],
+    temperature: 0,
+    temperatureText: "",
+    temperatureUnit: "",
+    temperatureUnitText: "",
+    alternativeTemperatures: [],
+  });
+});
+
+test("Parse instruction with unknown language with fallback en", () => {
+  const result = parseInstruction("some instruction", "en-CA", {
+    fallbackLanguage: "en",
+  });
+  expect(result).toEqual({
+    totalTimeInSeconds: 0,
+    timeItems: [],
+    temperature: 0,
+    temperatureText: "",
+    temperatureUnit: "",
+    temperatureUnitText: "",
+    alternativeTemperatures: [],
+  });
+});
+
 test("Parse instruction with undefined language", () => {
   expect(() => parseInstruction("some instruction", undefined)).toThrow(
     "Language undefined is not supported",


### PR DESCRIPTION
This pull request introduces a fallback mechanism for handling unsupported languages in the `parseInstruction` function. It ensures that if the primary language is not supported, a fallback language can be specified, improving robustness. Additionally, new tests have been added to validate the behavior of this fallback mechanism.

### Enhancements to language handling:

* Added a `fallbackLanguage` option to the `ParseInstructionOptions` type definition in `src/instructionParser.js`, allowing the specification of a fallback language.
* Updated the `defaultParseInstructionOptions` to include `fallbackLanguage` with an empty string as the default value.
* Modified the `parseInstruction` function to check for fallback language support when the primary language is not supported. If neither the primary nor fallback language is supported, an error is thrown with a detailed message.

### Test coverage improvements:

* Added tests in `test/index_invalid.spec.js` to validate the behavior of the fallback mechanism:
  - A test for unsupported language with no fallback specified.
  - Tests for unsupported language with fallback languages `en-US` and `en` specified, ensuring correct parsing results.