### PR TITLE
Add to taste handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -152,18 +152,25 @@ sharp-recipe-parser uses a simple technique that preserves words and punctuation
 ### Getting started
 1. Fork this repository and clone your fork locally
 2. This project uses Yarn Classic (v1). If you don't have it, install it via npm:
-   ```bash
+   ```sh
    npm install -g yarn
    ```
 3. Install dependencies:
-   ```bash
+   ```sh
    yarn install
    ```
 4. Run the test suite to confirm everything is working before making changes:
-   ```bash
+   ```sh
    yarn test
    ```
-
+5. Make sure changes align to `eslint` config:
+   ```sh
+   yarn lint
+   ```
+6. Check types:
+   ```sh
+   yarn run types
+   ```
 
 ## FAQ
 1. Why not use AI?

--- a/readme.md
+++ b/readme.md
@@ -143,10 +143,27 @@ sharp-recipe-parser uses a simple technique that preserves words and punctuation
    1. "180 degree celsius"
 
 ## Contribute
+### Guidelines
 1. By default regex is not allowed. If absolutely necessary, they will be reviewed in a case-by-case basis
 2. All changes need to have appropriate translation in the same PR
 3. Open an issue describing the problem you are trying to fix before opening a PR. That should help ensure all PRs are reviewed and approved.
 4. Please be nice. This is a work of love, not money.
+
+### Getting started
+1. Fork this repository and clone your fork locally
+2. This project uses Yarn Classic (v1). If you don't have it, install it via npm:
+   ```bash
+   npm install -g yarn
+   ```
+3. Install dependencies:
+   ```bash
+   yarn install
+   ```
+4. Run the test suite to confirm everything is working before making changes:
+   ```bash
+   yarn test
+   ```
+
 
 ## FAQ
 1. Why not use AI?

--- a/src/ingredientParser.js
+++ b/src/ingredientParser.js
@@ -104,13 +104,13 @@ export function parseIngredient(
       const lastToken = tokens[lastIdx];
       const possibleUnit = units.ingredientUnits.get(lastToken.toLowerCase());
 
-      if (possibleUnit) {
+      if (possibleUnit && possibleUnit.trailingOnly) {
         let markerIdx = lastIdx - 1;
         while (markerIdx >= 0 && tokens[markerIdx] === " ") markerIdx--;
 
         if (
           markerIdx >= 0 &&
-          units.ingredientRangeMarker.includes(tokens[markerIdx])
+          units.trailingUnitMarker.includes(tokens[markerIdx].toLowerCase())
         ) {
           unit = possibleUnit.text;
           unitText = lastToken;

--- a/src/ingredientParser.js
+++ b/src/ingredientParser.js
@@ -93,11 +93,36 @@ export function parseIngredient(
     tokens,
     units,
   );
-  const [unit, unitText, unitEndIndex] = getUnit(
+  let [unit, unitText, unitEndIndex] = getUnit(
     tokens,
     quantityEndIndex,
     units,
   );
+
+  let trailingUnitEndIndex = null;
+  if (!unit) {
+    let lastIdx = tokens.length - 1;
+    while (lastIdx >= 0 && tokens[lastIdx] === " ") lastIdx--;
+
+    if (lastIdx >= 2) {
+      const lastToken = tokens[lastIdx];
+      const possibleUnit = units.ingredientUnits.get(lastToken.toLowerCase());
+
+      if (possibleUnit) {
+        let markerIdx = lastIdx - 1;
+        while (markerIdx >= 0 && tokens[markerIdx] === " ") markerIdx--;
+
+        if (
+          markerIdx >= 0 &&
+          units.ingredientRangeMarker.includes(tokens[markerIdx])
+        ) {
+          unit = possibleUnit.text;
+          unitText = lastToken;
+          trailingUnitEndIndex = markerIdx;
+        }
+      }
+    }
+  }
 
   /**
    * @type {Types.AlternativeQuantity[]}
@@ -145,11 +170,14 @@ export function parseIngredient(
     tokens,
     ingredientStartIndex,
     units,
+    trailingUnitEndIndex,
   );
 
   let extra = "";
   if (options.includeExtra) {
-    extra = getExtra(tokens, ingredientEndIndex);
+    const extraStartIndex =
+      trailingUnitEndIndex !== null ? tokens.length : ingredientEndIndex;
+    extra = getExtra(tokens, extraStartIndex);
   }
 
   const minQuantity = firstQuantity || quantity;
@@ -335,15 +363,19 @@ function getUnit(tokens, startIndex, units) {
  * @param {string[]} tokens - The list of tokens to get the ingredient from.
  * @param {number} startIndex - The index of the first token to use when getting the ingredient.
  * @param {Types.Units} units - The unit dictionary to use when parsing the ingredient.
+ * @param {number | null} limitEndIndex - Optional upper bound on the token slice end index, used to exclude a trailing unit (e.g. "to taste") from the ingredient text.
  * @returns {[string, number]} The ingredient value and the index of the last token used to get the ingredient.
  */
-function getIngredient(tokens, startIndex, units) {
+function getIngredient(tokens, startIndex, units, limitEndIndex = null) {
   if (startIndex >= tokens.length) {
     return ["", startIndex];
   }
 
   const separatorIndex = tokens.findIndex((item) => item == ",");
-  const endIndex = separatorIndex > 0 ? separatorIndex : tokens.length;
+  let endIndex = separatorIndex > 0 ? separatorIndex : tokens.length;
+  if (limitEndIndex !== null) {
+    endIndex = Math.min(endIndex, limitEndIndex);
+  }
   const cleanTokens = [];
   let withinParenthesis = false;
 

--- a/src/ingredientParser.js
+++ b/src/ingredientParser.js
@@ -93,11 +93,7 @@ export function parseIngredient(
     tokens,
     units,
   );
-  let [unit, unitText, unitEndIndex] = getUnit(
-    tokens,
-    quantityEndIndex,
-    units,
-  );
+  let [unit, unitText, unitEndIndex] = getUnit(tokens, quantityEndIndex, units);
 
   let trailingUnitEndIndex = null;
   if (!unit) {

--- a/src/types.js
+++ b/src/types.js
@@ -4,6 +4,7 @@
  *  text: string;
  *  customFunction?: (tokens: string[], startIndex: number) => { uom: string; uomText: string; newIndex: number };
  *  conversionGroup?: string;
+ *  trailingOnly?: boolean;
  * }} UnitDetail
  */
 
@@ -36,6 +37,7 @@
  *  ingredientQuantities: Map<string, number>;
  *  ingredientRangeMarker: string[];
  *  ingredientQuantityAddMarker: string[];
+ *  trailingUnitMarker: string[];
  *  unitConversions: UnitConversion;
  *  defaultTemperatureUnit: string | null;
  * }} Units

--- a/src/units.en.js
+++ b/src/units.en.js
@@ -81,6 +81,7 @@ const quart = {
 const slice = { symbol: "slice", text: "slice" };
 const stalk = { symbol: "stalk", text: "stalk" };
 const stick = { symbol: "stick", text: "stick" };
+const taste = { symbol: "taste", text: "taste" };
 const teaspoon = {
   symbol: "tsp",
   text: "teaspoon",
@@ -181,6 +182,8 @@ ingredientUnits.set("sticks", stick);
 ingredientUnits.set("t", teaspoon);
 ingredientUnits.set("tablespoon", tablespoon);
 ingredientUnits.set("tablespoons", tablespoon);
+ingredientUnits.set("taste", taste);
+ingredientUnits.set("tastes", taste);
 ingredientUnits.set("tbs", tablespoon);
 ingredientUnits.set("tbsp", tablespoon);
 ingredientUnits.set("tbspn", tablespoon);

--- a/src/units.en.js
+++ b/src/units.en.js
@@ -81,7 +81,7 @@ const quart = {
 const slice = { symbol: "slice", text: "slice" };
 const stalk = { symbol: "stalk", text: "stalk" };
 const stick = { symbol: "stick", text: "stick" };
-const taste = { symbol: "taste", text: "taste" };
+const taste = { symbol: "taste", text: "taste", trailingOnly: true };
 const teaspoon = {
   symbol: "tsp",
   text: "teaspoon",
@@ -263,6 +263,8 @@ const ingredientRangeMarker = ["to", "-", "–", "or"];
 
 const ingredientQuantityAddMarker = ["and"];
 
+const trailingUnitMarker = ["to"];
+
 /**
  * @type {Map<string, string[]>}
  */
@@ -291,6 +293,7 @@ export default {
   ingredientQuantities,
   ingredientRangeMarker,
   ingredientQuantityAddMarker,
+  trailingUnitMarker,
   unitConversions,
   defaultTemperatureUnit: null,
 };

--- a/src/units.enUS.js
+++ b/src/units.enUS.js
@@ -111,6 +111,7 @@ export default {
   ingredientQuantities: DefaultEnglish.ingredientQuantities,
   ingredientRangeMarker: DefaultEnglish.ingredientRangeMarker,
   ingredientQuantityAddMarker: DefaultEnglish.ingredientQuantityAddMarker,
+  trailingUnitMarker: DefaultEnglish.trailingUnitMarker,
   unitConversions,
   defaultTemperatureUnit: "fahrenheit",
 };

--- a/src/units.pt.js
+++ b/src/units.pt.js
@@ -55,6 +55,7 @@ const pedaco = { symbol: "pedaço", text: "pedaço" };
 const pitada = { symbol: "pitada", text: "pitada" };
 const fatia = { symbol: "fatia", text: "fatia" };
 const bastao = { symbol: "bastão", text: "bastão" };
+const gosto = { symbol: "gosto", text: "gosto" };
 
 /**
  * @type {Map<string, UnitDetail>}
@@ -112,6 +113,7 @@ ingredientUnits.set("fatia", fatia);
 ingredientUnits.set("fatias", fatia);
 ingredientUnits.set("bastão", bastao);
 ingredientUnits.set("bastões", bastao);
+ingredientUnits.set("gosto", gosto);
 
 ingredientUnits.set("colher", { symbol: "colher", text: "colher" });
 ingredientUnits.set("colheres", { symbol: "colher", text: "colher" });

--- a/src/units.pt.js
+++ b/src/units.pt.js
@@ -55,7 +55,7 @@ const pedaco = { symbol: "pedaço", text: "pedaço" };
 const pitada = { symbol: "pitada", text: "pitada" };
 const fatia = { symbol: "fatia", text: "fatia" };
 const bastao = { symbol: "bastão", text: "bastão" };
-const gosto = { symbol: "gosto", text: "gosto" };
+const gosto = { symbol: "gosto", text: "gosto", trailingOnly: true };
 
 /**
  * @type {Map<string, UnitDetail>}
@@ -189,6 +189,8 @@ const ingredientRangeMarker = ["a", "-", "–", "ou"];
 
 const ingredientQuantityAddMarker = ["e"];
 
+const trailingUnitMarker = ["a"];
+
 /**
  * @type {Map<string, string[]>}
  */
@@ -217,6 +219,7 @@ export default {
   ingredientQuantities,
   ingredientRangeMarker,
   ingredientQuantityAddMarker,
+  trailingUnitMarker,
   unitConversions,
   defaultTemperatureUnit: null,
 };

--- a/src/units.ptBR.js
+++ b/src/units.ptBR.js
@@ -288,6 +288,7 @@ export default {
   ingredientQuantities: DefaultPortuguese.ingredientQuantities,
   ingredientRangeMarker: DefaultPortuguese.ingredientRangeMarker,
   ingredientQuantityAddMarker: DefaultPortuguese.ingredientQuantityAddMarker,
+  trailingUnitMarker: DefaultPortuguese.trailingUnitMarker,
   unitConversions,
   defaultTemperatureUnit: "celsius",
 };

--- a/test/index_en.spec.js
+++ b/test/index_en.spec.js
@@ -30,7 +30,7 @@ describe("Parse ingredient en-US", () => {
     ["5 cans of dried corn", 5, "5", "can", "dried corn", ""],
     ["½ cans of dried corn", 0.5, "½", "can", "dried corn", ""],
     ["10 ml milk", 10, "10", "milliliter", "milk", ""],
-    ["Salt to taste", 0, "", "", "Salt to taste", ""],
+    ["Salt to taste", 0, "", "taste", "Salt", ""],
     ["Ingredient", 0, "", "", "Ingredient", ""],
     ["10 gr wheat flour", 10, "10", "grain", "wheat flour", ""],
     ["1 drop of water", 1, "1", "drop", "water", ""],
@@ -57,6 +57,7 @@ describe("Parse ingredient en-US", () => {
     ["Pinch salt and pepper ($0.05)", 0, "", "pinch", "salt and pepper", ""],
     ["Pinch salt and pepper", 0, "", "pinch", "salt and pepper", ""],
     ["Salt and pepper", 0, "", "", "Salt and pepper", ""],
+    ["black pepper to taste", 0, "", "taste", "black pepper", ""]
   ];
   it.each(table)(
     "parse %s",

--- a/test/index_en.spec.js
+++ b/test/index_en.spec.js
@@ -57,7 +57,7 @@ describe("Parse ingredient en-US", () => {
     ["Pinch salt and pepper ($0.05)", 0, "", "pinch", "salt and pepper", ""],
     ["Pinch salt and pepper", 0, "", "pinch", "salt and pepper", ""],
     ["Salt and pepper", 0, "", "", "Salt and pepper", ""],
-    ["black pepper to taste", 0, "", "taste", "black pepper", ""]
+    ["black pepper to taste", 0, "", "taste", "black pepper", ""],
   ];
   it.each(table)(
     "parse %s",

--- a/test/index_en.spec.js
+++ b/test/index_en.spec.js
@@ -58,6 +58,8 @@ describe("Parse ingredient en-US", () => {
     ["Pinch salt and pepper", 0, "", "pinch", "salt and pepper", ""],
     ["Salt and pepper", 0, "", "", "Salt and pepper", ""],
     ["black pepper to taste", 0, "", "taste", "black pepper", ""],
+    ["Bacon strips or slices", 0, "", "", "Bacon strips or slices", ""],
+    ["Bread crumbs or piece", 0, "", "", "Bread crumbs or piece", ""],
   ];
   it.each(table)(
     "parse %s",

--- a/test/index_pt.spec.js
+++ b/test/index_pt.spec.js
@@ -53,6 +53,7 @@ describe("Parse ingredient pt-BR", () => {
     ["10l leite", 10, "10", "litro", "leite", ""],
     ["Sal a gosto", 0, "", "gosto", "Sal", ""],
     ["pimenta preta a gosto", 0, "", "gosto", "pimenta preta", ""],
+    ["presunto fatiado a pedaço", 0, "", "", "presunto fatiado a pedaço", ""],
     ["Ingrediente", 0, "", "", "Ingrediente", ""],
     ["1 gota de balnilha", 1, "1", "gota", "balnilha", ""],
     [

--- a/test/index_pt.spec.js
+++ b/test/index_pt.spec.js
@@ -51,7 +51,8 @@ describe("Parse ingredient pt-BR", () => {
     ["½ lata de milho seco", 0.5, "½", "lata", "milho seco", ""],
     ["10 ml leite", 10, "10", "mililitro", "leite", ""],
     ["10l leite", 10, "10", "litro", "leite", ""],
-    ["Sal a gosto", 0, "", "", "Sal a gosto", ""],
+    ["Sal a gosto", 0, "", "gosto", "Sal", ""],
+    ["pimenta preta a gosto", 0, "", "gosto", "pimenta preta", ""],
     ["Ingrediente", 0, "", "", "Ingrediente", ""],
     ["1 gota de balnilha", 1, "1", "gota", "balnilha", ""],
     [


### PR DESCRIPTION
Adds logic to handle "to taste" as part of an ingredient listing.  Things like "black pepper to taste" will now come out as "black pepper" as the ingredient and "to taste" as the quantity.  

Other things to note:
- This also changes an existing unit test that had "salt to taste" staying as the full string "salt to taste".  While I don't like breaking existing logic I would make the argument that "to taste" is not actually part of the ingredient.  
- Both "to" (in English) and "a" (in Portuguese) are common phrases so it needs "taste" or "gosto" before including "to" or "a" in the unit identification.
- This uses `ingredientRangeMarker` for the logic change but perhaps a separate `trailingUnitMarker` list would be preferable.  